### PR TITLE
Feature/update sidebar#31

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,7 @@
 class PagesController < ApplicationController
   def top
   end
+
+  def help
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,4 @@
 class PagesController < ApplicationController
-  def home
+  def top
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,9 +32,10 @@
                       %i.fas.fa-user{"aria-hidden" => "true"}
                       %span{:style => "margin-left:6px;"} マイページ
                   %li
-                    %a{:href => "#"}
+                    %a{:href => "users/edit"}
                       %i.fas.fa-cog{"aria-hidden" => "true"}
                       %span{:style => "margin-left:6px;"} 設定
+
                   %li
                     %a{:href => "#"}
                       %i.fas.fa-question-circle{"aria-hidden" => "true"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,25 +19,26 @@
       = link_to "ログイン", new_user_session_path, class: "float-right btn btn-info mt-4 mr-4"
     .container
       .row
-        .col-1
-          #wrapper
-            #sidebar-wrapper
-              %ul.sidebar-nav{:style => "margin-left:0;"}
-                %li.sidebar-brand
-                  %a#menu-toggle{:href => "#menu-toggle", :style => "margin-top:20px;float:right;"}
-                    %i.fas.fa-bars{"aria-hidden" => "true", :style => "font-size:20px !Important;"}
-                %li
-                  %a{:href => "#"}
-                    %i.fas.fa-user{"aria-hidden" => "true"}
-                    %span{:style => "margin-left:6px;"} マイページ
-                %li
-                  %a{:href => "#"}
-                    %i.fas.fa-cog{"aria-hidden" => "true"}
-                    %span{:style => "margin-left:6px;"} 設定
-                %li
-                  %a{:href => "#"}
-                    %i.fas.fa-question-circle{"aria-hidden" => "true"}
-                    %span{:style => "margin-left:6px;"} ヘルプ
+        - if user_signed_in?
+          .col-1
+            #wrapper
+              #sidebar-wrapper
+                %ul.sidebar-nav{:style => "margin-left:0;"}
+                  %li.sidebar-brand
+                    %a#menu-toggle{:href => "#menu-toggle", :style => "margin-top:20px;float:right;"}
+                      %i.fas.fa-bars{"aria-hidden" => "true", :style => "font-size:20px !Important;"}
+                  %li
+                    %a{:href => "#"}
+                      %i.fas.fa-user{"aria-hidden" => "true"}
+                      %span{:style => "margin-left:6px;"} マイページ
+                  %li
+                    %a{:href => "#"}
+                      %i.fas.fa-cog{"aria-hidden" => "true"}
+                      %span{:style => "margin-left:6px;"} 設定
+                  %li
+                    %a{:href => "#"}
+                      %i.fas.fa-question-circle{"aria-hidden" => "true"}
+                      %span{:style => "margin-left:6px;"} ヘルプ
 
           / Page Content
         .col-11

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,16 +28,16 @@
                     %a#menu-toggle{:href => "#menu-toggle", :style => "margin-top:20px;float:right;"}
                       %i.fas.fa-bars{"aria-hidden" => "true", :style => "font-size:20px !Important;"}
                   %li
-                    %a{:href => "#"}
+                    %a{:href => "#{user_path(current_user.id)}"}
                       %i.fas.fa-user{"aria-hidden" => "true"}
                       %span{:style => "margin-left:6px;"} マイページ
                   %li
-                    %a{:href => "users/edit"}
+                    %a{:href => "#{edit_user_registration_path(current_user.id)}"}
                       %i.fas.fa-cog{"aria-hidden" => "true"}
                       %span{:style => "margin-left:6px;"} 設定
 
                   %li
-                    %a{:href => "#"}
+                    %a{:href => "#{pages_help_path}"}
                       %i.fas.fa-question-circle{"aria-hidden" => "true"}
                       %span{:style => "margin-left:6px;"} ヘルプ
 

--- a/app/views/pages/help.html.haml
+++ b/app/views/pages/help.html.haml
@@ -1,0 +1,2 @@
+%h1 Help
+%p Sample text.

--- a/app/views/pages/top.html.haml
+++ b/app/views/pages/top.html.haml
@@ -1,3 +1,3 @@
-- provide(:title, "Home")
+- provide(:title, "Top")
 %h1 Circle
 %p これは仮ページです

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'pages#top'
+  get 'pages/help'
 
    resources :users, only: %i(index show)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'pages#home'
+  root 'pages#top'
 
    resources :users, only: %i(index show)
 end


### PR DESCRIPTION
fixes #31 

# 実装内容

-  ログイン時のみサイドバーを表示
- 仮ページを作成（マイページ、ヘルプ）
- リンクを追加
	- マイページ: user_path_path(current_user.id)
	- 設定: edit_user_registration_path(current_user.id)
	- ヘルプ: pages_help_path
- rootページの名前を変更: home => top


## 備考

なし
