### PR TITLE
Feature/add test data#44

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem 'mysql2'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 4.0.1'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,11 @@ GEM
     erubi (1.9.0)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.13.1)
     font-awesome-sass (5.13.0)
       sassc (>= 1.11)
@@ -259,6 +264,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   coffee-rails (~> 4.2)
   devise
+  factory_bot_rails
   font-awesome-sass (~> 5.13.0)
   haml-rails (~> 2.0)
   jbuilder (~> 2.5)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,4 +5,10 @@ FactoryBot.define do
     password { "password" }
     password_confirmation { "password" }
   end
+  factory :other_use, class: User do
+    username { 'testuser2' }
+    email { 'testuser2@rails.com' }
+    password { 'foobar' }
+    password_confirmation { 'foobar' }
+  end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    username { "testuser1" }
+    email { "testuser1@example.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,4 +68,8 @@ RSpec.configure do |config|
       driven_by :selenium, using: :headless_chrome, screen_size: [1280, 800], options: { args: ["headless", "disable-gpu", "no-sandbox", "disable-dev-shm-usage"] }
     end
   end
+
+  # rspecのテストコード中でFactory_botのメソッドを使用する際に、クラス名の指定を省略できるようにする
+  config.include FactoryBot::Syntax::Methods
+
 end


### PR DESCRIPTION
fixes #44 

# 実装内容

- gemを導入 factory_bot_rails
- factory botデータ登録(user, other_uesr)
- rspecのテストコード中でFactory_botのメソッドを使用する際に、クラス名の指定を省略できるようにする

## 備考

なし
